### PR TITLE
Add Terraform configuration for Airflow deployment

### DIFF
--- a/terraform/airflow/main.tf
+++ b/terraform/airflow/main.tf
@@ -1,0 +1,27 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+# Basic VM for Airflow
+resource "google_compute_instance" "airflow" {
+  name         = "airflow-vm"
+  machine_type = "e2-small"
+  zone         = var.zone
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+      size  = 25
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      // Ephemeral public IP
+    }
+  }
+
+  tags = ["airflow"]
+} 

--- a/terraform/airflow/outputs.tf
+++ b/terraform/airflow/outputs.tf
@@ -1,0 +1,9 @@
+output "airflow_vm_ip" {
+  description = "The IP address of the Airflow VM"
+  value       = google_compute_instance.airflow.network_interface[0].access_config[0].nat_ip
+}
+
+output "airflow_vm_name" {
+  description = "The name of the Airflow VM"
+  value       = google_compute_instance.airflow.name
+} 

--- a/terraform/airflow/variables.tf
+++ b/terraform/airflow/variables.tf
@@ -1,0 +1,16 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "asia-east1"
+}
+
+variable "zone" {
+  description = "GCP zone"
+  type        = string
+  default     = "asia-east1-a"
+} 


### PR DESCRIPTION
- Created main.tf to define a Google Compute Engine instance for Airflow.
- Added outputs.tf to expose the VM's IP address and name.
- Defined variables in variables.tf for project ID, region, and zone.