### PR TITLE
Update Airflow Terraform configuration to include dependencies for IA…

### DIFF
--- a/terraform/airflow/main.tf
+++ b/terraform/airflow/main.tf
@@ -34,6 +34,7 @@ resource "google_project_iam_member" "scheduler_sa_roles" {
   project = var.project_id
   role    = each.key
   member  = "serviceAccount:${google_service_account.scheduler_sa.email}"
+  depends_on = [google_service_account.scheduler_sa]
 }
 
 # Create Cloud Scheduler job for starting Airflow VM
@@ -43,6 +44,7 @@ resource "google_cloud_scheduler_job" "start_airflow" {
   schedule    = "0 8 * * 6"  # Every Saturday at 8:00 AM
   time_zone   = "Asia/Taipei"
   region      = var.region
+  depends_on  = [google_service_account.scheduler_sa, google_project_iam_member.scheduler_sa_roles]
 
   http_target {
     http_method = "POST"
@@ -60,6 +62,7 @@ resource "google_cloud_scheduler_job" "stop_airflow" {
   schedule    = "0 0 * * 0"  # Every Sunday at 00:00
   time_zone   = "Asia/Taipei"
   region      = var.region
+  depends_on  = [google_service_account.scheduler_sa, google_project_iam_member.scheduler_sa_roles]
 
   http_target {
     http_method = "POST"

--- a/terraform/airflow/variables.tf
+++ b/terraform/airflow/variables.tf
@@ -12,7 +12,7 @@ variable "region" {
 variable "zone" {
   description = "GCP zone"
   type        = string
-  default     = "asia-east1-a"
+  default     = "asia-east1-b"
 }
 
 variable "environment" {


### PR DESCRIPTION
…M roles and Cloud Scheduler jobs

- Added `depends_on` attributes to ensure proper resource creation order for IAM roles and Cloud Scheduler jobs.
- Changed the default GCP zone variable from "asia-east1-a" to "asia-east1-b" in variables.tf.