### PR TITLE
Add service account check and import logic in Jenkinsfile

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -12,7 +12,7 @@ variable "region" {
 variable "zone" {
   description = "The GCP zone for VM instances"
   type        = string
-  default     = "asia-east1-a"
+  default     = "asia-east1-b"
 }
 
 variable "aws_access_key" {


### PR DESCRIPTION
- Introduced a new stage in the Jenkins pipeline to check for the existence of the service account in GCP and import it into Terraform state if it is not already present.
- Updated the default GCP zone variable from "asia-east1-a" to "asia-east1-b" in variables.tf.