### PR TITLE
Update upload_config.sh to reference new file paths for Docker config…

### DIFF
--- a/scripts/upload_config.sh
+++ b/scripts/upload_config.sh
@@ -4,8 +4,8 @@
 mkdir -p docker/config
 
 # Copy files to temporary directory
-cp docker-compose.yml docker/
-cp config/airflow.cfg docker/config/
+cp ../terraform/airflow/docker/docker-compose.yml docker/
+cp ../terraform/airflow/docker/config/airflow.cfg docker/config/
 
 # Upload to GCS
 gsutil -m cp -r docker/* gs://open-data-v2-cicd-airflow-storage/docker/


### PR DESCRIPTION
…uration

- Changed paths in upload_config.sh to copy docker-compose.yml and airflow.cfg from the Terraform directory, ensuring correct file locations for the upload process to Google Cloud Storage.