### PR TITLE
Update upload_config.sh and main.tf to enhance Airflow configuration

### DIFF
--- a/scripts/upload_config.sh
+++ b/scripts/upload_config.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Set bucket name
+BUCKET_NAME="open-data-v2-cicd-airflow-storage"
+
 # Create temporary directories
 mkdir -p docker/config
 
@@ -8,7 +11,7 @@ cp ../terraform/airflow/docker/docker-compose.yml docker/
 cp ../terraform/airflow/docker/config/airflow.cfg docker/config/
 
 # Upload to GCS
-gsutil -m cp -r docker/* gs://open-data-v2-cicd-airflow-storage/docker/
+gsutil -m cp -r docker/* gs://${BUCKET_NAME}/docker/
 
 # Clean up
 rm -rf docker/ 


### PR DESCRIPTION
- Set bucket name as a variable in upload_config.sh for improved maintainability.
- Updated gsutil command to use the new BUCKET_NAME variable for uploading Docker files.
- Added Google Secret Manager resources in main.tf to manage service account keys securely.
- Implemented IAM roles for Secret Manager access to enhance security for the Airflow setup.